### PR TITLE
Use `FileDescriptor` from `MediaStore` for random file access

### DIFF
--- a/Nearby Sharing Windows/FileUtils.cs
+++ b/Nearby Sharing Windows/FileUtils.cs
@@ -11,9 +11,7 @@ internal static class FileUtils
     {
         var fileName = contentResolver.QueryContentName(contentUri);
 
-        using var fd = contentResolver.OpenAssetFileDescriptor(contentUri, "r") ?? throw new IOException("Could not open file");
-        var stream = fd.CreateInputStream() ?? throw new IOException("Could not open input stream");
-
+        var stream = contentResolver.OpenInputStream(contentUri) ?? throw new IOException("Could not open input stream");
         return CdpFileProvider.FromStream(fileName, stream);
     }
 
@@ -24,20 +22,63 @@ internal static class FileUtils
         return returnCursor.GetString(0) ?? throw new IOException("Could not query content name");
     }
 
-    public static Stream CreateMediaStoreStream(this ContentResolver resolver, string fileName)
+    public static (AndroidUri uri, FileStream stream) CreateMediaStoreStream(this ContentResolver resolver, string fileName)
     {
         ContentValues contentValues = new();
         contentValues.Put(MediaStore.IMediaColumns.DisplayName, fileName);
-        if (OperatingSystem.IsAndroidVersionAtLeast(29))
+
+        FileStream stream;
+        AndroidUri mediaUri;
+        if (!OperatingSystem.IsAndroidVersionAtLeast(29))
+        {
+            stream = CreateDownloadFile(fileName);
+
+            contentValues.Put(MediaStore.IMediaColumns.Data, stream.Name);
+            mediaUri = resolver.Insert(contentValues);
+        }
+        else
+        {
             contentValues.Put(MediaStore.IMediaColumns.RelativePath, "Download/Nearby Sharing/");
+            mediaUri = resolver.Insert(contentValues);
 
-        var mediaUri = resolver.Insert(
+            stream = resolver.OpenFileStream(mediaUri);
+        }
+
+        return (mediaUri, stream);
+    }
+
+    public static FileStream OpenFileStream(this ContentResolver resolver, AndroidUri mediaUri)
+    {
+        var fileDescriptor = resolver.OpenFileDescriptor(mediaUri, "rwt") ?? throw new InvalidOperationException("Could not open file descriptor");
+
+        SafeFileHandle handle = new(fileDescriptor.Fd, ownsHandle: false);
+        return new(handle, FileAccess.ReadWrite);
+    }
+
+    static AndroidUri Insert(this ContentResolver resolver, ContentValues contentValues)
+    {
+        return resolver.Insert(
             MediaStore.Files.GetContentUri("external") ?? throw new InvalidOperationException("Could not get external content uri"),
-            contentValues) ?? throw new InvalidOperationException("Could not insert into MediaStore");
+            contentValues
+        ) ?? throw new InvalidOperationException("Could not insert into MediaStore");
+    }
 
-        var fileDescriptor = resolver.OpenFileDescriptor(mediaUri, "rwt") ?? throw new InvalidOperationException("Could not file");
-        SafeFileHandle handle = new(fileDescriptor.Fd, ownsHandle: true);
-        return new FileStream(handle, FileAccess.ReadWrite);
+    static FileStream CreateDownloadFile(string fileName)
+    {
+        var downloadDir = AndroidEnvironment.GetExternalStoragePublicDirectory(AndroidEnvironment.DirectoryDownloads)?.AbsolutePath
+            ?? throw new NullReferenceException("Could not get download directory");
+
+        string filePath = Path.Combine(downloadDir, fileName);
+        if (!File.Exists(filePath))
+            return File.Create(filePath);
+
+        var fileNameCore = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        for (int i = 1; File.Exists(filePath); i++)
+        {
+            filePath = Path.Combine(downloadDir, $"{fileNameCore} ({i}){extension}");
+        }
+        return File.Create(filePath);
     }
 
     public static string GetLogFilePattern(this Activity activity)

--- a/Nearby Sharing Windows/FileUtils.cs
+++ b/Nearby Sharing Windows/FileUtils.cs
@@ -49,9 +49,9 @@ internal static class FileUtils
 
     public static FileStream OpenFileStream(this ContentResolver resolver, AndroidUri mediaUri)
     {
-        var fileDescriptor = resolver.OpenFileDescriptor(mediaUri, "rwt") ?? throw new InvalidOperationException("Could not open file descriptor");
-
-        SafeFileHandle handle = new(fileDescriptor.Fd, ownsHandle: false);
+        using var fileDescriptor = resolver.OpenFileDescriptor(mediaUri, "rwt") ?? throw new InvalidOperationException("Could not open file descriptor");
+        
+        SafeFileHandle handle = new(fileDescriptor.DetachFd(), ownsHandle: true);
         return new(handle, FileAccess.ReadWrite);
     }
 

--- a/Nearby Sharing Windows/GlobalUsings.cs
+++ b/Nearby Sharing Windows/GlobalUsings.cs
@@ -1,2 +1,3 @@
 ﻿global using AndroidUri = Android.Net.Uri;
+global using AndroidEnvironment = Android.OS.Environment;
 global using ManifestPermission = Android.Manifest.Permission;

--- a/Nearby Sharing Windows/Nearby Sharing Windows.csproj
+++ b/Nearby Sharing Windows/Nearby Sharing Windows.csproj
@@ -11,7 +11,6 @@
 		<ApplicationDisplayVersion>1.7.0</ApplicationDisplayVersion>
 		<UseAndroidCrypto>true</UseAndroidCrypto>
 		<AndroidErrorOnCustomJavaObject>false</AndroidErrorOnCustomJavaObject>
-		<EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<RunAOTCompilation>False</RunAOTCompilation>

--- a/Nearby Sharing Windows/Nearby Sharing Windows.csproj
+++ b/Nearby Sharing Windows/Nearby Sharing Windows.csproj
@@ -11,6 +11,7 @@
 		<ApplicationDisplayVersion>1.7.0</ApplicationDisplayVersion>
 		<UseAndroidCrypto>true</UseAndroidCrypto>
 		<AndroidErrorOnCustomJavaObject>false</AndroidErrorOnCustomJavaObject>
+		<EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<RunAOTCompilation>False</RunAOTCompilation>

--- a/Nearby Sharing Windows/ReceiveActivity.cs
+++ b/Nearby Sharing Windows/ReceiveActivity.cs
@@ -131,7 +131,7 @@ public sealed class ReceiveActivity : AppCompatActivity
 
             try
             {
-                var streams = fileTransfer.Select(file => ContentResolver!.CreateMediaStoreStream(file.Name)).ToArray();
+                var streams = fileTransfer.Select(file => ContentResolver!.CreateMediaStoreStream(file.Name).stream).ToArray();
                 fileTransfer.Accept(streams);
 
                 fileTransfer.Finished += () =>

--- a/Nearby Sharing Windows/SendActivity.cs
+++ b/Nearby Sharing Windows/SendActivity.cs
@@ -251,14 +251,14 @@ public sealed class SendActivity : AppCompatActivity
                         {
 #endif
                         progressIndicator.Indeterminate = false;
-                        progressIndicator.Max = (int)args.TotalBytesToSend;
-                        progressIndicator.SetProgressCompat((int)args.BytesSent, animated: true);
+                        progressIndicator.Max = (int)args.TotalBytes;
+                        progressIndicator.SetProgressCompat((int)args.TransferedBytes, animated: true);
 
-                        if (args.TotalFilesToSend != 0 && args.TotalBytesToSend != 0)
+                        if (args.TotalFiles != 0 && args.TotalBytes != 0)
                         {
                             StatusTextView.Text = this.Localize(
                                 Resource.String.sending_template,
-                                args.TotalFilesToSend
+                                args.TotalFiles
                             );
                         }
 #if !DEBUG

--- a/ShortDev.Microsoft.ConnectedDevices.NearShare/NearShareProgress.cs
+++ b/ShortDev.Microsoft.ConnectedDevices.NearShare/NearShareProgress.cs
@@ -2,8 +2,7 @@
 
 public sealed class NearShareProgress
 {
-    public required ulong BytesSent { get; init; }
-    public required uint FilesSent { get; init; }
-    public required ulong TotalBytesToSend { get; init; }
-    public required uint TotalFilesToSend { get; init; }
+    public required ulong TransferedBytes { get; init; }
+    public required ulong TotalBytes { get; init; }
+    public required uint TotalFiles { get; init; }
 }

--- a/ShortDev.Microsoft.ConnectedDevices.NearShare/NearShareSender.cs
+++ b/ShortDev.Microsoft.ConnectedDevices.NearShare/NearShareSender.cs
@@ -181,10 +181,9 @@ public sealed class NearShareSender(ConnectedDevicesPlatform platform)
 
             _fileProgress?.Report(new()
             {
-                BytesSent = Interlocked.Add(ref _bytesSent, length),
-                FilesSent = contentId + 1, // ToDo: How to calculate?
-                TotalBytesToSend = _bytesToSend,
-                TotalFilesToSend = (uint)_files.Count
+                TransferedBytes = Interlocked.Add(ref _bytesSent, length),
+                TotalBytes = _bytesToSend,
+                TotalFiles = (uint)_files.Count
             });
 
             ValueSet response = new();

--- a/ShortDev.Microsoft.ConnectedDevices.NearShare/TransferToken.cs
+++ b/ShortDev.Microsoft.ConnectedDevices.NearShare/TransferToken.cs
@@ -12,13 +12,16 @@ public sealed class UriTransferToken : TransferToken
     public required string Uri { get; init; }
 }
 
-public record struct FileShareInfo(uint Id, string Name, ulong Size);
+public readonly record struct FileShareInfo(uint Id, string Name, ulong Size);
 
 public sealed class FileTransferToken : TransferToken, IEnumerable<FileShareInfo>
 {
-    public required uint TotalFilesToSend { get; init; }
-    public required ulong TotalBytesToSend { get; init; }
+    public uint TotalFiles => (uint)Files.Count;
+    public required ulong TotalBytes { get; init; }
     public required IReadOnlyList<FileShareInfo> Files { get; init; }
+
+    public IEnumerator<FileShareInfo> GetEnumerator() => Files.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     #region Formatting
     public static string FormatFileSize(ulong fileSize)
@@ -40,27 +43,29 @@ public sealed class FileTransferToken : TransferToken, IEnumerable<FileShareInfo
     #endregion
 
     #region Acceptance
-    readonly TaskCompletionSource<IReadOnlyList<Stream>> _promise = new();
+    readonly TaskCompletionSource<IReadOnlyList<Stream>> _acceptPromise = new();
     internal async ValueTask AwaitAcceptance()
-        => await _promise.Task;
+        => await _acceptPromise.Task;
 
     public bool IsAccepted
-        => _promise.Task.IsCompletedSuccessfully;
+        => _acceptPromise.Task.IsCompletedSuccessfully;
 
-    public void Accept(IReadOnlyList<Stream> fileStream)
+    public void Accept(IReadOnlyList<Stream> streams)
     {
-        if (fileStream.Count != TotalFilesToSend)
-            throw new ArgumentException("Invalid number of streams", nameof(fileStream));
+        if (streams.Count != TotalFiles)
+            throw new ArgumentException("Invalid number of streams", nameof(streams));
 
-        _promise.SetResult(fileStream);
+        _acceptPromise.SetResult(streams);
     }
 
     internal Stream GetStream(uint contentId)
     {
         for (int i = 0; i < Files.Count; i++)
         {
-            if (Files[i].Id == contentId)
-                return _promise.Task.Result[i];
+            if (Files[i].Id != contentId)
+                continue;
+
+            return _acceptPromise.Task.Result[i];
         }
 
         throw new ArgumentOutOfRangeException(nameof(contentId));
@@ -74,49 +79,35 @@ public sealed class FileTransferToken : TransferToken, IEnumerable<FileShareInfo
     public CancellationToken CancellationToken => _cancellationSource.Token;
     public void Cancel()
     {
-        _promise.TrySetCanceled();
+        _acceptPromise.TrySetCanceled();
         _cancellationSource.Cancel();
     }
     #endregion
 
 
     #region Progress
-    public bool IsTransferComplete { get; internal set; }
+    public bool IsTransferComplete { get; private set; }
 
     public event Action<NearShareProgress>? Progress;
 
-    internal ulong BytesSent { get; set; }
-    internal uint FilesSent { get; set; }
-
-    internal void SendProgressEvent()
+    ulong _transferedBytes = 0;
+    internal void SendProgressEvent(ulong byteTransferDelta)
     {
+        _transferedBytes += byteTransferDelta;
         NearShareProgress progress = new()
         {
-            BytesSent = BytesSent,
-            FilesSent = FilesSent,
-            TotalBytesToSend = TotalBytesToSend,
-            TotalFilesToSend = TotalFilesToSend,
+            TransferedBytes = _transferedBytes,
+            TotalBytes = TotalBytes,
+            TotalFiles = TotalFiles,
         };
-        IsTransferComplete = progress.BytesSent >= progress.TotalBytesToSend;
+        IsTransferComplete = progress.TransferedBytes >= progress.TotalBytes;
         _ = Task.Run(() => Progress?.Invoke(progress));
     }
     #endregion
 
-    #region Info
-    public IEnumerator<FileShareInfo> GetEnumerator()
-        => Files.GetEnumerator();
-
-    IEnumerator IEnumerable.GetEnumerator()
-        => GetEnumerator();
-    #endregion
-
-    internal void Close()
+    public event Action? Finished;
+    internal void OnFinish()
     {
-        foreach (var stream in _promise.Task.Result)
-        {
-            stream.Flush();
-            stream.Close();
-            stream.Dispose();
-        }
+        _ = Task.Run(() => Finished?.Invoke());
     }
 }


### PR DESCRIPTION
## Issue
As file-transfer packages might be received out of order, a seekable stream (random file access) is needed.
But: Android APIs don't provide random file access with `MediaStore`.
Manually creating a file in the downloads folder might result in an `UnauthorizedAccessException`.

## Solution
Insert entry intro `MediaStore` (visible in files app) and use the `FileDescriptor` from `OpenFileDescriptor` to create a seekabe `FileStream` (dotnet).

---

Fixes #125   
Fixes #124