### PR TITLE
Fix dialog on background thread

### DIFF
--- a/src/SendActivity.cs
+++ b/src/SendActivity.cs
@@ -122,7 +122,7 @@ public sealed class SendActivity : AppCompatActivity
         _logger.RequestPermissionResult(requestCode, permissions, grantResults);
         try
         {
-            await Task.Run(InitializePlatform).ConfigureAwait(false);
+            await Task.Run(InitializePlatform);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Remove `.ConfigureAwait(false)` in ui code to ensure dialog will be created on the ui thread