### PR TITLE
Fallback to `Environment.MachineName`

### DIFF
--- a/src/Settings/SettingsFragment.cs
+++ b/src/Settings/SettingsFragment.cs
@@ -39,6 +39,6 @@ internal abstract class SettingsFragment : PreferenceFragmentCompat
         if (string.IsNullOrEmpty(deviceName))
             deviceName = adapter.Name;
 
-        return deviceName ?? throw new NullReferenceException("Could not find device name");
+        return deviceName ?? Environment.MachineName;
     }
 }


### PR DESCRIPTION
If the user did not explicitly set a device name and we cannot extract it from the bluetooth adapter use `Environment.MachineName` as fallback.