### PR TITLE
fix: exception on transfer cancel

### DIFF
--- a/src/ReceiveActivity.cs
+++ b/src/ReceiveActivity.cs
@@ -180,7 +180,13 @@ public sealed class ReceiveActivity : AppCompatActivity
                 return;
 
             if (_transfer is FileTransferToken fileTransfer)
-                fileTransfer.Cancel();
+            {
+                try
+                {
+                    fileTransfer.Cancel();
+                }
+                catch { }
+            }
 
             OnRemove(_transfer);
         }


### PR DESCRIPTION
Ignore exceptions on transfer cancel as the underlying socket might long be closed.