### PR TITLE
fix: check request permission result

### DIFF
--- a/src/MainActivity.cs
+++ b/src/MainActivity.cs
@@ -9,6 +9,7 @@ using Google.Android.Material.Dialog;
 using Google.Android.Material.TextField;
 using NearShare.Utils;
 using ShortDev.Android.UI;
+using System.Security;
 
 namespace NearShare;
 
@@ -172,8 +173,14 @@ public sealed class MainActivity : AppCompatActivity
     {
         try
         {
-            if (OperatingSystem.IsAndroidVersionAtLeast(31))
-                await _requestPermissionsLauncher.RequestAsync();
+            if (OperatingSystem.IsAndroidVersionAtLeast(31) && await _requestPermissionsLauncher.RequestAsync() is PermissionResult.Denied)
+            {
+                if (!this.IsAtLeastStarted)
+                    return;
+
+                this.ShowErrorDialog(new SecurityException("Bluetooth permission denied"));
+                return;
+            }
 
             StartActivityForResult(new Intent(BluetoothAdapter.ActionRequestEnable), 0);
         }


### PR DESCRIPTION
A user might deny the bluetooth permission needed to request to enable bluetooth. The app used to throw in this case.
Now it shows an error dialog.