### PR TITLE
fix: don't initialize cdp if `ReceiveActivity` has finished

### DIFF
--- a/src/ReceiveActivity.cs
+++ b/src/ReceiveActivity.cs
@@ -260,6 +260,9 @@ public sealed class ReceiveActivity : AppCompatActivity
         {
             await _intentResultListener.LaunchAsync(new Intent(BluetoothAdapter.ActionRequestEnable));
 
+            if (!this.IsAtLeastStarted)
+                return;
+
             await Task.Run(InitializePlatform);
         }
         catch (Exception ex)


### PR DESCRIPTION
The app possibly crashes if the `ReceiveActivity` finishes before the permission intent get's resolved.